### PR TITLE
Use qualified "error" from Prelude in a function

### DIFF
--- a/large-records/src/Data/Record/Internal/Plugin/CodeGen.hs
+++ b/large-records/src/Data/Record/Internal/Plugin/CodeGen.hs
@@ -203,7 +203,8 @@ genVectorConversions QualifiedNames{..} r@Record{..} = concatM [
                         ]
                     )
                   , ( wildP
-                    , VarE unq_error `appE` stringE matchErr
+                       -- VarE unq_error `appE` stringE matchErr
+                    ,  VarE (noLoc $ mkRdrQual (mkModuleName "Prelude") (mkVarOcc "error")) `appE` stringE matchErr
                     )
                   ]
           ]

--- a/large-records/test/Test/Record/Sanity/OverloadedRecordUpdate.hs
+++ b/large-records/test/Test/Record/Sanity/OverloadedRecordUpdate.hs
@@ -40,6 +40,7 @@ import Data.Record.Generic (Rep)
 import Data.Record.Generic.Lens.VL
 import Data.Record.Overloading
 import Data.Record.Plugin
+import qualified Prelude ( error )
 
 tests :: TestTree
 tests = testGroup "Test.Record.Sanity.OverloadedRecordUpdate" [


### PR DESCRIPTION
Use the qualified version `Prelude.error` instead of an unqualified `error` in `large-records/src/Data/Record/Internal/Plugin/CodeGen.hs` in fn `toVector` of top-level fn `genVectorConversions`.

This is to avoid name collisions with records with fields also named "error", which then need further work-arounds of their own.
This small change here, in my understanding, reduces/prevents the need to do those work-arounds there.

This PR/commit:-
- Replaces the unqualified "error" with a qualified version (Prelude.error).
- Edit one test file, which needed an import of qualified `error`

Edit:- wording. ( Aug 11 20:43 )